### PR TITLE
Update to target multiple frameworks (netcoreapp3.1 and net5.0)

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.101",
+    "version": "5.0.101",
 	"rollForward": "latestFeature"
   }
 }

--- a/src/Weikio.PluginFramework.AspNetCore/Weikio.PluginFramework.AspNetCore.csproj
+++ b/src/Weikio.PluginFramework.AspNetCore/Weikio.PluginFramework.AspNetCore.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Plugin Framework for ASP.NET Core.</Description>

--- a/src/Weikio.PluginFramework.Catalogs.NuGet/Weikio.PluginFramework.Catalogs.NuGet.csproj
+++ b/src/Weikio.PluginFramework.Catalogs.NuGet/Weikio.PluginFramework.Catalogs.NuGet.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>NuGet catalog for Plugin Framework allows you to use NuGet packages as plugins with Plugin Framework.</Description>

--- a/src/Weikio.PluginFramework.Catalogs.Roslyn/Weikio.PluginFramework.Catalogs.Roslyn.csproj
+++ b/src/Weikio.PluginFramework.Catalogs.Roslyn/Weikio.PluginFramework.Catalogs.Roslyn.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Roslyn catalog for Plugin Framework allows you to use Roslyn scripts as plugins with Plugin Framework.</Description>

--- a/src/Weikio.PluginFramework.Configuration/Weikio.PluginFramework.Configuration.csproj
+++ b/src/Weikio.PluginFramework.Configuration/Weikio.PluginFramework.Configuration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <nullable>enable</nullable>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Weikio.PluginFramework/Weikio.PluginFramework.csproj
+++ b/src/Weikio.PluginFramework/Weikio.PluginFramework.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Plugin Framework is a powerful plugin platform for your .NET Core applications.</Description>

--- a/tests/integration/Weikio.PluginFramework.Catalogs.NuGet.Tests/Weikio.PluginFramework.Catalogs.NuGet.Tests.csproj
+++ b/tests/integration/Weikio.PluginFramework.Catalogs.NuGet.Tests/Weikio.PluginFramework.Catalogs.NuGet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/unit/Weikio.PluginFramework.Catalogs.Roslyn.Tests/Weikio.PluginFramework.Catalogs.Roslyn.Tests.csproj
+++ b/tests/unit/Weikio.PluginFramework.Catalogs.Roslyn.Tests/Weikio.PluginFramework.Catalogs.Roslyn.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/unit/Weikio.PluginFramework.Tests/Weikio.PluginFramework.Tests.csproj
+++ b/tests/unit/Weikio.PluginFramework.Tests/Weikio.PluginFramework.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Resolves #36 

- Update library projects and tests to target both .NET Core 3.1 and .NET 5.0
