### PR TITLE
#24 Allow configuring default plugin that is returned from DI

### DIFF
--- a/samples/WebApp/Controllers/CalculatorController.cs
+++ b/samples/WebApp/Controllers/CalculatorController.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Weikio.PluginFramework.Samples.Shared;
 using Weikio.PluginFramework.Abstractions;
@@ -11,19 +13,24 @@ namespace WebApp.Controllers
     {
         private readonly IEnumerable<IOperator> _operators;
         private readonly IEnumerable<Plugin> _plugins;
+        private readonly IOperator _defaultOperator;
 
-        public CalculatorController(IEnumerable<IOperator> operators, IEnumerable<Plugin> plugins, IOperator myOperator)
+        public CalculatorController(IEnumerable<IOperator> operators, IEnumerable<Plugin> plugins, IOperator defaultOperator)
         {
             _operators = operators;
             _plugins = plugins;
+            _defaultOperator = defaultOperator;
         }
         
         [HttpGet]
         public string Get()
         {
-            var pluginsList = string.Join(", ", _plugins);
-
-            return pluginsList;
+            return JsonSerializer.Serialize(new
+            {
+                allPlugins = _plugins.Select(p => p.ToString()),
+                operators = _operators.Select(o => o.GetType().Name),
+                defaultOperator = _defaultOperator.GetType().Name
+            }, new JsonSerializerOptions { WriteIndented = true});
         }
     }
 }

--- a/samples/WebApp/Startup.cs
+++ b/samples/WebApp/Startup.cs
@@ -6,7 +6,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Weikio.PluginFramework.Samples.Shared;
 using Weikio.PluginFramework.Abstractions;
+using Weikio.PluginFramework.AspNetCore;
 using Weikio.PluginFramework.Catalogs;
+using Weikio.PluginFramework.Samples.SharedPlugins;
 
 namespace WebApp
 {
@@ -33,6 +35,18 @@ namespace WebApp
 
             // Alternatively
             // services.AddPluginFramework<IOperator>(@"..\Shared\Weikio.PluginFramework.Samples.SharedPlugins\bin\debug\netcoreapp3.1");
+
+            // Default plugin type returned can be optionally configured with DefaultType function
+            //services.AddPluginFramework()
+            //    .AddPluginCatalog(folderPluginCatalog)
+            //    .AddPluginType<IOperator>(configureDefault: option =>
+            //    {
+            //        option.DefaultType = (serviceProvider, implementingTypes) => typeof(MultiplyOperator);
+            //    });
+
+            // Alternatively default plugin type can be also configured with Configure and provided with the same DefaultType function
+            //services.Configure<DefaultPluginOption>(nameof(IOperator), option =>
+            //    option.DefaultType = (serviceProvider, implementingTypes) => typeof(MultiplyOperator));
 
             services.AddControllers();
         }

--- a/src/Weikio.PluginFramework.AspNetCore/DefaultPluginOption.cs
+++ b/src/Weikio.PluginFramework.AspNetCore/DefaultPluginOption.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Weikio.PluginFramework.AspNetCore
+{
+    public class DefaultPluginOption
+    {
+        public Func<IServiceProvider, IEnumerable<Type>, Type> DefaultType { get; set; }
+            = (serviceProvider, implementingTypes) => implementingTypes.FirstOrDefault();
+    }
+}

--- a/src/Weikio.PluginFramework.Configuration/Weikio.PluginFramework.Configuration.csproj
+++ b/src/Weikio.PluginFramework.Configuration/Weikio.PluginFramework.Configuration.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>


### PR DESCRIPTION
Resolves #24 

- Allows configuring default plugin that is returned from DI with two ways: by using Configure from IServiceCollection or by using configuration method from AddPluginType.