### PR TITLE
#34 Configuration for NuGet

### DIFF
--- a/samples/WebApp/Startup.cs
+++ b/samples/WebApp/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Weikio.PluginFramework.Samples.Shared;
 using Weikio.PluginFramework.Abstractions;
+using Weikio.PluginFramework.AspNetCore;
 using Weikio.PluginFramework.Catalogs;
 
 namespace WebApp

--- a/samples/WebAppWithAppSettings/Startup.cs
+++ b/samples/WebAppWithAppSettings/Startup.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Weikio.PluginFramework.Catalogs.NuGet;
 using Weikio.PluginFramework.Samples.Shared;
 using Weikio.PluginFramework.TypeFinding;
 
@@ -13,7 +14,8 @@ namespace WebAppWithAppSettings
         {
             TypeFinderOptions.Defaults.TypeFinderCriterias.Add(TypeFinderCriteriaBuilder.Create().Implements<IOperator>().Tag("MathOperator"));
             TypeFinderOptions.Defaults.TypeFinderCriterias.Add(TypeFinderCriteriaBuilder.Create().Tag("All"));
-            services.AddPluginFramework();
+            services.AddPluginFramework()
+                .AddNugetConfiguration();
             
             services.AddControllers();
         }

--- a/samples/WebAppWithAppSettings/WebAppWithAppSettings.csproj
+++ b/samples/WebAppWithAppSettings/WebAppWithAppSettings.csproj
@@ -6,6 +6,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\..\src\Weikio.PluginFramework.AspNetCore\Weikio.PluginFramework.AspNetCore.csproj" />
+      <ProjectReference Include="..\..\src\Weikio.PluginFramework.Catalogs.NuGet\Weikio.PluginFramework.Catalogs.NuGet.csproj" />
       <ProjectReference Include="..\Shared\Weikio.PluginFramework.Samples.SharedPlugins\Weikio.PluginFramework.Samples.SharedPlugins.csproj" />
       <ProjectReference Include="..\Shared\Weikio.PluginFramework.Samples.Shared\Weikio.PluginFramework.Samples.Shared.csproj" />
       <ProjectReference Include="..\WebAppPluginsLibrary\WebAppPluginsLibrary.csproj" />

--- a/samples/WebAppWithDelegate/Startup.cs
+++ b/samples/WebAppWithDelegate/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Weikio.PluginFramework.AspNetCore;
 using Weikio.PluginFramework.Catalogs;
 using Weikio.PluginFramework.Catalogs.Delegates;
 
@@ -53,6 +54,7 @@ namespace WebAppWithDelegate
 
             services.AddPluginFramework()
                 .AddPluginCatalog(new CompositePluginCatalog(actionCatalog, funcCatalog, funcWithExternalServiceCatalog));
+
 
             services.AddSingleton<ExternalService>();
             services.AddControllers();

--- a/samples/WebAppWithNuget/Startup.cs
+++ b/samples/WebAppWithNuget/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Weikio.PluginFramework.AspNetCore;
 using Weikio.PluginFramework.Catalogs;
 using Weikio.PluginFramework.Catalogs.NuGet;
 using Weikio.PluginFramework.Samples.Shared;

--- a/samples/WebAppWithRoslyn/Startup.cs
+++ b/samples/WebAppWithRoslyn/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Weikio.PluginFramework.AspNetCore;
 using Weikio.PluginFramework.Catalogs;
 using Weikio.PluginFramework.Catalogs.Roslyn;
 

--- a/src/PluginFramework.sln
+++ b/src/PluginFramework.sln
@@ -61,11 +61,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinFormsApp", "..\samples\W
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinFormsPluginsLibrary", "..\samples\WinFormsPluginsLibrary\WinFormsPluginsLibrary.csproj", "{E92B0C5D-FFAC-4AB9-B069-869AEED565B0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Weikio.PluginFramework.Configuration", "Weikio.PluginFramework.Configuration\Weikio.PluginFramework.Configuration.csproj", "{882BB58E-D256-4BBF-8C5F-80C4FA39B775}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Weikio.PluginFramework.Configuration", "Weikio.PluginFramework.Configuration\Weikio.PluginFramework.Configuration.csproj", "{882BB58E-D256-4BBF-8C5F-80C4FA39B775}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAppWithAppSettings", "..\samples\WebAppWithAppSettings\WebAppWithAppSettings.csproj", "{A5FAE1A5-74A0-4A83-9520-DCABF6610ADE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebAppWithAppSettings", "..\samples\WebAppWithAppSettings\WebAppWithAppSettings.csproj", "{A5FAE1A5-74A0-4A83-9520-DCABF6610ADE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAppPluginsLibrary", "..\samples\WebAppPluginsLibrary\WebAppPluginsLibrary.csproj", "{38CCE0F7-F998-4766-A14A-44C047E8D0AA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebAppPluginsLibrary", "..\samples\WebAppPluginsLibrary\WebAppPluginsLibrary.csproj", "{38CCE0F7-F998-4766-A14A-44C047E8D0AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Weikio.PluginFramework.Abstractions.DependencyInjection", "Weikio.PluginFramework.Abstractions.DependencyInjection\Weikio.PluginFramework.Abstractions.DependencyInjection.csproj", "{64FD5284-87A2-4A6D-8CCD-324CDD944A11}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -185,6 +187,10 @@ Global
 		{38CCE0F7-F998-4766-A14A-44C047E8D0AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{38CCE0F7-F998-4766-A14A-44C047E8D0AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{38CCE0F7-F998-4766-A14A-44C047E8D0AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64FD5284-87A2-4A6D-8CCD-324CDD944A11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64FD5284-87A2-4A6D-8CCD-324CDD944A11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64FD5284-87A2-4A6D-8CCD-324CDD944A11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64FD5284-87A2-4A6D-8CCD-324CDD944A11}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Weikio.PluginFramework.Abstractions.DependencyInjection/IPluginFrameworkBuilder.cs
+++ b/src/Weikio.PluginFramework.Abstractions.DependencyInjection/IPluginFrameworkBuilder.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Weikio.PluginFramework.Abstractions.DependencyInjection
+{
+    public interface IPluginFrameworkBuilder
+    {
+        IServiceCollection Services { get; }
+    }
+}

--- a/src/Weikio.PluginFramework.Abstractions.DependencyInjection/Weikio.PluginFramework.Abstractions.DependencyInjection.csproj
+++ b/src/Weikio.PluginFramework.Abstractions.DependencyInjection/Weikio.PluginFramework.Abstractions.DependencyInjection.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.5" />
+  </ItemGroup>
+
+</Project>

--- a/src/Weikio.PluginFramework.AspNetCore/PluginFrameworkBuilder.cs
+++ b/src/Weikio.PluginFramework.AspNetCore/PluginFrameworkBuilder.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Weikio.PluginFramework.Abstractions.DependencyInjection;
+
+namespace Weikio.PluginFramework.AspNetCore
+{
+    public class PluginFrameworkBuilder : IPluginFrameworkBuilder
+    {
+        public PluginFrameworkBuilder(IServiceCollection services)
+        {
+            Services = services;
+        }
+
+        public IServiceCollection Services { get; }
+    }
+}

--- a/src/Weikio.PluginFramework.AspNetCore/PluginFrameworkBuilderExtensions.cs
+++ b/src/Weikio.PluginFramework.AspNetCore/PluginFrameworkBuilderExtensions.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Weikio.PluginFramework.Abstractions;
+using Weikio.PluginFramework.Abstractions.DependencyInjection;
+
+namespace Weikio.PluginFramework.AspNetCore
+{
+    public static class PluginFrameworkBuilderExtensions
+    {
+        public static IPluginFrameworkBuilder AddPluginCatalog(this IPluginFrameworkBuilder builder, IPluginCatalog pluginCatalog)
+        {
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton(typeof(IPluginCatalog), pluginCatalog));
+
+            return builder;
+        }
+
+        public static IPluginFrameworkBuilder AddPluginType<T>(this IPluginFrameworkBuilder builder, ServiceLifetime serviceLifetime = ServiceLifetime.Transient)
+            where T : class
+        {
+            var serviceDescriptorEnumerable = new ServiceDescriptor(typeof(IEnumerable<T>), sp =>
+            {
+                var pluginProvider = sp.GetService<PluginProvider>();
+                var result = pluginProvider.GetTypes<T>();
+
+                return result.AsEnumerable();
+            }, serviceLifetime);
+
+            var serviceDescriptorSingle = new ServiceDescriptor(typeof(T), sp =>
+            {
+                var pluginProvider = sp.GetService<PluginProvider>();
+                var result = pluginProvider.GetTypes<T>();
+
+                return result.FirstOrDefault();
+            }, serviceLifetime);
+
+            builder.Services.Add(serviceDescriptorEnumerable);
+            builder.Services.Add(serviceDescriptorSingle);
+
+            return builder;
+        }
+    }
+}

--- a/src/Weikio.PluginFramework.AspNetCore/Weikio.PluginFramework.AspNetCore.csproj
+++ b/src/Weikio.PluginFramework.AspNetCore/Weikio.PluginFramework.AspNetCore.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Weikio.PluginFramework.Abstractions.DependencyInjection\Weikio.PluginFramework.Abstractions.DependencyInjection.csproj" />
     <ProjectReference Include="..\Weikio.PluginFramework.Abstractions\Weikio.PluginFramework.Abstractions.csproj" />
     <ProjectReference Include="..\Weikio.PluginFramework.Configuration\Weikio.PluginFramework.Configuration.csproj" />
     <ProjectReference Include="..\Weikio.PluginFramework\Weikio.PluginFramework.csproj" />

--- a/src/Weikio.PluginFramework.Catalogs.NuGet/NugetFeedCatalogConfigurationConverter.cs
+++ b/src/Weikio.PluginFramework.Catalogs.NuGet/NugetFeedCatalogConfigurationConverter.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Weikio.NugetDownloader;
+using Weikio.PluginFramework.Abstractions;
+using Weikio.PluginFramework.Configuration.Converters;
+using Weikio.PluginFramework.TypeFinding;
+
+namespace Weikio.PluginFramework.Catalogs.NuGet
+{
+    public class NugetFeedCatalogConfigurationConverter : IConfigurationToCatalogConverter
+    {
+        public bool CanConvert(string type)
+        {
+            return string.Equals(type, "NugetFeed", StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public IPluginCatalog Convert(IConfigurationSection configuration)
+        {
+            var feedName = configuration.GetValue<string>("Name")
+                              ?? throw new ArgumentException("Plugin Framework's NugetFeedCatalog requires a NuGet package name.");
+
+            var feedUrl = configuration.GetValue<string>("Feed")
+                           ?? throw new ArgumentException("Plugin Framework's NugetFeedCatalog requires a NuGet feed url.");
+
+            var searchTerm = configuration.GetValue<string>("SearchTerm")
+                           ?? throw new ArgumentException("Plugin Framework's NugetFeedCatalog requires a NuGet search term");
+
+            var options = new NugetFeedOptions();
+            configuration.Bind("Options", options);
+
+            return new NugetFeedPluginCatalog(new NuGetFeed(feedName, feedUrl)
+            {
+                Username = options.UserName,
+                Password = options.Password
+            }, searchTerm, options.IncludePreRelease, options.MaxPackages ?? 128);
+        }
+    }
+
+    class NugetFeedOptions
+    {
+        public string UserName { get; set; }
+
+        public string Password { get; set; }
+
+        public bool IncludePreRelease { get; set; }
+
+        public int? MaxPackages { get; set; }
+    }
+}

--- a/src/Weikio.PluginFramework.Catalogs.NuGet/NugetPackageCatalogConfigurationConverter.cs
+++ b/src/Weikio.PluginFramework.Catalogs.NuGet/NugetPackageCatalogConfigurationConverter.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Weikio.PluginFramework.Abstractions;
+using Weikio.PluginFramework.Configuration.Converters;
+
+namespace Weikio.PluginFramework.Catalogs.NuGet
+{
+    public class NugetPackageCatalogConfigurationConverter : IConfigurationToCatalogConverter
+    {
+        public bool CanConvert(string type)
+        {
+            return string.Equals(type, "NugetPackage", StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public IPluginCatalog Convert(IConfigurationSection configuration)
+        {
+            var packageName = configuration.GetValue<string>("Name")
+                       ?? throw new ArgumentException("Plugin Framework's NugetPackageCatalog requires a NuGet package name.");
+
+            var packageVersion = configuration.GetValue<string>("Version")
+                              ?? throw new ArgumentException("Plugin Framework's NugetPackageCatalog requires a NuGet package version.");
+
+            return new NugetPackagePluginCatalog(packageName, packageVersion, true);
+        }
+    }
+}

--- a/src/Weikio.PluginFramework.Catalogs.NuGet/PluginFrameworkBuilderExtensions.cs
+++ b/src/Weikio.PluginFramework.Catalogs.NuGet/PluginFrameworkBuilderExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Weikio.PluginFramework.Abstractions.DependencyInjection;
+using Weikio.PluginFramework.Configuration.Converters;
+
+namespace Weikio.PluginFramework.Catalogs.NuGet
+{
+    public static class PluginFrameworkBuilderExtensions
+    {
+        public static IPluginFrameworkBuilder AddNugetConfiguration(this IPluginFrameworkBuilder builder)
+        {
+            builder.Services.AddTransient(typeof(IConfigurationToCatalogConverter), typeof(NugetFeedCatalogConfigurationConverter));
+            builder.Services.AddTransient(typeof(IConfigurationToCatalogConverter), typeof(NugetPackageCatalogConfigurationConverter));
+
+            return builder;
+        }
+    }
+}

--- a/src/Weikio.PluginFramework.Catalogs.NuGet/Weikio.PluginFramework.Catalogs.NuGet.csproj
+++ b/src/Weikio.PluginFramework.Catalogs.NuGet/Weikio.PluginFramework.Catalogs.NuGet.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Weikio.PluginFramework.Abstractions.DependencyInjection\Weikio.PluginFramework.Abstractions.DependencyInjection.csproj" />
     <ProjectReference Include="..\Weikio.PluginFramework.Abstractions\Weikio.PluginFramework.Abstractions.csproj" />
     <ProjectReference Include="..\Weikio.PluginFramework.Configuration\Weikio.PluginFramework.Configuration.csproj" />
     <ProjectReference Include="..\Weikio.PluginFramework\Weikio.PluginFramework.csproj" />

--- a/src/Weikio.PluginFramework.Catalogs.NuGet/Weikio.PluginFramework.Catalogs.NuGet.csproj
+++ b/src/Weikio.PluginFramework.Catalogs.NuGet/Weikio.PluginFramework.Catalogs.NuGet.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Weikio.PluginFramework.Abstractions\Weikio.PluginFramework.Abstractions.csproj" />
+    <ProjectReference Include="..\Weikio.PluginFramework.Configuration\Weikio.PluginFramework.Configuration.csproj" />
     <ProjectReference Include="..\Weikio.PluginFramework\Weikio.PluginFramework.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolves #34 

- Implement configuration converters for NuGet packages and feeds
- Changes how PluginFramework is initialized by using PluginFrameworkBuilder. This was done so that AddNugetConfiguration extension could be implemented.